### PR TITLE
Dockerization of yamcs quickstart

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,3 @@
-FROM maven:latest
+FROM maven:3.6-openjdk-11
 
 WORKDIR /yamcs
-
-RUN git clone https://github.com/yamcs/quickstart.git .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM maven:latest
+
+WORKDIR /yamcs
+
+RUN git clone https://github.com/yamcs/quickstart.git .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,19 @@
+
+
+all:
+	$(MAKE) yamcs-simulator
+	
+yamcs-build: ## build yamcs system
+	docker build . -t yamcs
+
+yamcs-up: | yamcs-build yamcs-down ## bring up yamcs system
+	docker-compose up -d
+
+yamcs-down: ## bring down yamcs system
+	docker-compose down -v --remove-orphans
+
+yamcs-simulator: yamcs-up ## run yamcs simulator
+	cd .. && python ./simulator.py
+
+yamcs-shell: ## shell into yamcs container
+	docker run -it yamcs "bash"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,8 @@
+.DEFAULT_GOAL := help
 
-
-all:
+all: ## run all, yamcs-build, yamcs-up (yamcs-down) and yamcs-simulator
 	$(MAKE) yamcs-simulator
-	
+  
 yamcs-build: ## build yamcs system
 	docker build . -t yamcs
 
@@ -13,7 +13,18 @@ yamcs-down: ## bring down yamcs system
 	docker-compose down -v --remove-orphans
 
 yamcs-simulator: yamcs-up ## run yamcs simulator
+	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
 	cd .. && python ./simulator.py
 
-yamcs-shell: ## shell into yamcs container
-	docker run -it yamcs "bash"
+yamcs-shell: yamcs-build ## shell into yamcs container
+	docker-compose up -d && docker run -it yamcs "bash"
+
+help:
+	@printf "\033[37m%-30s\033[0m %s\n" "#----------------------------------------------------------------------------------"
+	@printf "\033[37m%-30s\033[0m %s\n" "# Makefile                                          "
+	@printf "\033[37m%-30s\033[0m %s\n" "#----------------------------------------------------------------------------------"
+	@printf "\033[37m%-30s\033[0m %s\n" "#-targets----------------------description-----------------------------------------"
+	@grep -E '^[a-zA-Z_-].+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+print-%:
+	@echo $* = $($*)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,41 @@
+# Yamcs QuickStart's Docker and Makefile
+
+This folder contains content to run yamcs in a docker container
+
+## Prerequisites
+
+* make
+* docker
+* docker-compose
+
+## Builing, running, and simulating data in Yamcs
+
+Here are some commands to get things started:
+
+To list available make targets:
+
+    make
+
+To run the all target:
+
+    make all
+
+To build yamcs:
+
+    make yamcs-build
+
+To bring up yamcs container:
+
+    make yamcs-up
+
+To bring down yamcs container:
+
+    make yamcs-down
+
+To run simulator by connecting to container:
+
+    make yamcs-simulator
+
+To shell into yamcs container:
+
+    make yamcs-shell

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+
+services:
+  yamcs:
+    image: "yamcs"
+    hostname: yamcs
+    container_name: yamcs
+    command: "mvn yamcs:run"
+    ports:
+      - "127.0.0.1:8090:8090"
+      - "127.0.0.1:10015:10015/udp"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     hostname: yamcs
     container_name: yamcs
     command: "mvn yamcs:run"
+    volumes:
+      - ../:/yamcs
     ports:
       - "127.0.0.1:8090:8090"
       - "127.0.0.1:10015:10015/udp"


### PR DESCRIPTION
Dockerization of yamcs quickstart. In the `./docker` folder, there is a `Makefile` and running `make` yields:

```
#---------------------------------------------------------------------------------- 
# Makefile                                           
#---------------------------------------------------------------------------------- 
#-targets----------------------description----------------------------------------- 
all                            run all, yamcs-build, yamcs-up (yamcs-down) and yamcs-simulator
yamcs-build                    build yamcs system
yamcs-down                     bring down yamcs system
yamcs-shell                    shell into yamcs container
yamcs-simulator                run yamcs simulator
yamcs-up                       bring up yamcs system
```


