### PR TITLE
feat(#32): Add a `clean` step to the Makefile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,49 +1,58 @@
-ifeq ($(shell which python3),)
-  PYTHON = python
-else
-  PYTHON = python3
-endif
+SHELL := /bin/bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+PYTHON := $(shell command -v python3 2>/dev/null || echo python)
 
 .DEFAULT_GOAL := help
 
+# Define function to print messages in different colors
+# Usage: $(call print_message,ANSI_COLOR_CODE,Your message here)
 define print_message
-	@printf "\033[32m$1\033[0m\n"
+	@printf "\033[$(1)m$(2)\033[0m\n"
 endef
 
-all: clean ## run all, clean, yamcs-up (yamcs-down) and yamcs-simulator
-	$(MAKE) yamcs-simulator
-  
+.PHONY: all clean yamcs-up yamcs-down yamcs-simulator yamcs-shell help
+
+all: clean yamcs-simulator ## run all: clean, yamcs-up (yamcs-down) and yamcs-simulator
+
 yamcs-up: | yamcs-down ## bring up yamcs system
 	docker compose up -d
 
 yamcs-down: ## bring down yamcs system
+	$(call print_message,33,Stopping any running docker-yamcs containers...)
 	docker compose down -v --remove-orphans
 
 yamcs-simulator: yamcs-up ## run yamcs simulator
-	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
+	$(call print_message,36,Connect via http://localhost:8090/ system may take about 50 seconds to startup)
 	cd .. && $(PYTHON) ./simulator.py
 
 yamcs-shell: ## shell into yamcs container
 	docker compose up -d && docker compose exec yamcs bash
 
-clean: ## remove yamcs build artifacts and Docker resources created by this Makefile
-	$(call print_message, "Stopping any running docker-yamcs containers...")
-	docker compose down -v --remove-orphans
-	$(call print_message, "Cleaning up docker-yamcs resources (containers, volumes, networks)...")
+clean: | yamcs-down ## remove yamcs build artifacts and docker resources created by this Makefile
+	$(call print_message,33,Cleaning up docker-yamcs resources (containers, volumes, networks)...)
 	docker compose rm -f -s -v
-	$(call print_message, "Removing docker-yamcs image...")
-	docker image rm -f docker-yamcs || true
-	$(call print_message, "Cleaning up yamcs build artifacts...")
+	$(call print_message,33,Removing docker-yamcs image...)
+	docker image rm -f docker-yamcs 2>/dev/null || true
+	$(call print_message,33,Cleaning up yamcs build artifacts...)
 	rm -rf ../target
-	$(call print_message, "Done!")
+	$(call print_message,32,Done!)
 
-help:
-	$(call print_message, "#----------------------------------------------------------------------------------")
-	$(call print_message, "# Makefile                                          ")
-	$(call print_message, "#----------------------------------------------------------------------------------")
-	$(call print_message, "#-targets----------------------description-----------------------------------------")
-	@grep -E '^[a-zA-Z_-].+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+TERM_WIDTH := $(shell tput cols 2>/dev/null || echo 80)
 
-print-%:
+define print_header
+	@printf '%*s\n' "$(TERM_WIDTH)" '' | tr ' ' '-'
+	@printf '%-*s\n' "$(TERM_WIDTH)" "$(1)"
+	@printf '%*s\n' "$(TERM_WIDTH)" '' | tr ' ' '-'
+endef
+
+help: ## display this help message
+	$(call print_header,"Makefile")
+	@awk 'BEGIN {FS = ":.*##"; printf "\033[36m%-30s\033[0m %s\n", "Target", "Description"} /^[a-zA-Z_-]+:.*?##/ {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+print-%: ## Print any variable (e.g., make print-PYTHON)
 	@echo $* = $($*)
-	

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ endif
 
 .DEFAULT_GOAL := help
 
-all: ## run all, yamcs-up (yamcs-down) and yamcs-simulator
+all: clean ## run all, clean, yamcs-up (yamcs-down) and yamcs-simulator
 	$(MAKE) yamcs-simulator
   
 yamcs-up: | yamcs-down ## bring up yamcs system
@@ -22,6 +22,12 @@ yamcs-simulator: yamcs-up ## run yamcs simulator
 yamcs-shell: ## shell into yamcs container
 	docker compose up -d && docker compose exec yamcs bash
 
+clean: ## remove yamcs build artifacts and Docker resources created by this Makefile
+	docker compose down -v --remove-orphans
+	docker compose rm -f -s -v
+	docker image rm -f docker-yamcs || true
+	rm -rf ../target
+
 help:
 	@printf "\033[37m%-30s\033[0m %s\n" "#----------------------------------------------------------------------------------"
 	@printf "\033[37m%-30s\033[0m %s\n" "# Makefile                                          "
@@ -31,3 +37,4 @@ help:
 
 print-%:
 	@echo $* = $($*)
+	

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,6 +6,10 @@ endif
 
 .DEFAULT_GOAL := help
 
+define print_message
+	@printf "\033[32m$1\033[0m\n"
+endef
+
 all: clean ## run all, clean, yamcs-up (yamcs-down) and yamcs-simulator
 	$(MAKE) yamcs-simulator
   
@@ -23,16 +27,21 @@ yamcs-shell: ## shell into yamcs container
 	docker compose up -d && docker compose exec yamcs bash
 
 clean: ## remove yamcs build artifacts and Docker resources created by this Makefile
+	$(call print_message, "Stopping any running docker-yamcs containers...")
 	docker compose down -v --remove-orphans
+	$(call print_message, "Cleaning up docker-yamcs resources (containers, volumes, networks)...")
 	docker compose rm -f -s -v
+	$(call print_message, "Removing docker-yamcs image...")
 	docker image rm -f docker-yamcs || true
+	$(call print_message, "Cleaning up yamcs build artifacts...")
 	rm -rf ../target
+	$(call print_message, "Done!")
 
 help:
-	@printf "\033[37m%-30s\033[0m %s\n" "#----------------------------------------------------------------------------------"
-	@printf "\033[37m%-30s\033[0m %s\n" "# Makefile                                          "
-	@printf "\033[37m%-30s\033[0m %s\n" "#----------------------------------------------------------------------------------"
-	@printf "\033[37m%-30s\033[0m %s\n" "#-targets----------------------description-----------------------------------------"
+	$(call print_message, "#----------------------------------------------------------------------------------")
+	$(call print_message, "# Makefile                                          ")
+	$(call print_message, "#----------------------------------------------------------------------------------")
+	$(call print_message, "#-targets----------------------description-----------------------------------------")
 	@grep -E '^[a-zA-Z_-].+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 print-%:


### PR DESCRIPTION
Fixes #32 

- Adds a `clean` step to the Makefile
- Run the `clean` step as the first step in `make all` to ensure reproducible builds

Plus...

- Refactor and modernize the `Makefile`
  - Add `.PHONY`, `.ONESHELL`, and other modern Makefile best-practices to increase robustness
    - Use the full path to the python3 executable
    - use /bin/bash as the shell
    - `.ONESHELL` - run all commands in a recipe in a single shell
    - `.SHELLFLAGS`
      - `-e`: Exit immediately if a command exits with non-zero exit code
      - `-u`: Treat unset variables as an error when substituting
      - `-o pipefail`: Return value of a pipeline is the status of the last command to exit with a non-zero status
  - Add `print_message` helper function to print colorized messages to the terminal
  - Dynamically calculate the width of the terminal in order to print better headers