### PR TITLE
Allow simulator playback rate to be optional specified at runtime

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,10 @@ endif
 
 all: ## run all, yamcs-up (yamcs-down) and yamcs-simulator
 	$(MAKE) yamcs-simulator
-  
+
+all-10hz: 
+        $(MAKE) yamcs-simulator-10hz
+
 yamcs-up: | yamcs-down ## bring up yamcs system
 	docker-compose up -d
 
@@ -18,7 +21,13 @@ yamcs-down: ## bring down yamcs system
 yamcs-simulator: yamcs-up ## run yamcs simulator
 	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
         export SIMULATOR_PLAYBACK_RATE="${SIMULATOR_PLAYBACK_RATE}:-1"
-	cd .. && $(PYTHON) ./simulator.py --rate=$SIMULATOR_PLAYBACK_RATE
+	cd .. && $(PYTHON) ./simulator.py
+
+yamcs-simulator-10-hz: yamcs-up ## run yamcs simulator
+        @echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
+        export SIMULATOR_PLAYBACK_RATE="${SIMULATOR_PLAYBACK_RATE}:-1"
+        cd .. && $(PYTHON) ./simulator.py --rate=10
+
 
 yamcs-shell: ## shell into yamcs container
 	docker-compose up -d && docker run -it yamcs "bash"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ all: ## run all, yamcs-up (yamcs-down) and yamcs-simulator
 	$(MAKE) yamcs-simulator
 
 all-10hz: 
-        $(MAKE) yamcs-simulator-10hz
+	$(MAKE) yamcs-simulator-10hz
 
 yamcs-up: | yamcs-down ## bring up yamcs system
 	docker-compose up -d
@@ -20,14 +20,11 @@ yamcs-down: ## bring down yamcs system
 
 yamcs-simulator: yamcs-up ## run yamcs simulator
 	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
-        export SIMULATOR_PLAYBACK_RATE="${SIMULATOR_PLAYBACK_RATE}:-1"
 	cd .. && $(PYTHON) ./simulator.py
 
-yamcs-simulator-10-hz: yamcs-up ## run yamcs simulator
-        @echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
-        export SIMULATOR_PLAYBACK_RATE="${SIMULATOR_PLAYBACK_RATE}:-1"
-        cd .. && $(PYTHON) ./simulator.py --rate=10
-
+yamcs-simulator-10hz: yamcs-up ## run yamcs simulator
+	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
+	cd .. && $(PYTHON) ./simulator.py --rate=10
 
 yamcs-shell: ## shell into yamcs container
 	docker-compose up -d && docker run -it yamcs "bash"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,7 +17,8 @@ yamcs-down: ## bring down yamcs system
 
 yamcs-simulator: yamcs-up ## run yamcs simulator
 	@echo "connect via http://localhost:8090/ system make take about 50 seconds to startup" && \
-	cd .. && $(PYTHON) ./simulator.py
+        export SIMULATOR_PLAYBACK_RATE="${SIMULATOR_PLAYBACK_RATE}:-1"
+	cd .. && $(PYTHON) ./simulator.py --rate=$SIMULATOR_PLAYBACK_RATE
 
 yamcs-shell: ## shell into yamcs container
 	docker-compose up -d && docker run -it yamcs "bash"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     Update this to the latest Yamcs release.
     Check https://mvnrepository.com/artifact/org.yamcs/yamcs-core
     -->
-    <yamcsVersion>5.8.5</yamcsVersion>
+    <yamcsVersion>5.8.8</yamcsVersion>
   </properties>
 
   <dependencies>

--- a/simulator.py
+++ b/simulator.py
@@ -5,7 +5,7 @@ import sys
 from struct import unpack_from
 from threading import Thread
 from time import sleep
-
+from argparse import ArgumentParser
 
 def send_tm(simulator):
     tm_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -23,7 +23,7 @@ def send_tm(simulator):
             tm_socket.sendto(packet, ('127.0.0.1', 10015))
             simulator.tm_counter += 1
 
-            sleep(0.1)
+            sleep(1 / simulator.rate)
 
 
 def receive_tc(simulator):
@@ -37,12 +37,13 @@ def receive_tc(simulator):
 
 class Simulator():
 
-    def __init__(self):
+    def __init__(self, rate):
         self.tm_counter = 0
         self.tc_counter = 0
         self.tm_thread = None
         self.tc_thread = None
         self.last_tc = None
+        self.rate = rate
 
     def start(self):
         self.tm_thread = Thread(target=send_tm, args=(self,))
@@ -61,7 +62,14 @@ class Simulator():
 
 
 if __name__ == '__main__':
-    simulator = Simulator()
+    parser = ArgumentParser()
+    parser.add_argument("-r", "--rate",
+        dest="rate",
+        default=1,
+        type=int,
+        help="Playback rate. 1 = 1Hz, 10 = 10Hz, etc.")
+    args = parser.parse_args()
+    simulator = Simulator(args.rate)
     simulator.start()
 
     try:

--- a/simulator.py
+++ b/simulator.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     simulator = Simulator(args.rate)
     simulator.start()
-
+    sys.stdout.write('Using playback rate of ' + str(args.rate) + 'Hz \r\n');
     try:
         prev_status = None
         while True:

--- a/simulator.py
+++ b/simulator.py
@@ -23,7 +23,7 @@ def send_tm(simulator):
             tm_socket.sendto(packet, ('127.0.0.1', 10015))
             simulator.tm_counter += 1
 
-            sleep(1)
+            sleep(0.1)
 
 
 def receive_tc(simulator):


### PR DESCRIPTION
Optional command line parameter for specifying the simulator playback rate.

* Adds a dependency to the builtin `argparse` package.
* Adds new makefile targets for launching simulator at 10Hz in automated testing.

To Do:
* [ ] Resolve merge conflicts